### PR TITLE
Update max-firefox-conf.js

### DIFF
--- a/max-firefox-conf/etc/firefox/pref/max-firefox-conf.js
+++ b/max-firefox-conf/etc/firefox/pref/max-firefox-conf.js
@@ -1,3 +1,5 @@
 // evitar la denegación de ejecución de plugins no actualizados
 // github #492 https://github.com/max-linux/max-desktop/issues/492
 pref("extensions.blocklist.enabled",false);
+// evitar que deniegue conexiones seguras via proxy a partir de la versión 27 de firefox
+pref("security.tls.version.max",1);


### PR DESCRIPTION
evitar que deniegue conexiones seguras vía proxy a partir de la versión 27 de firefox
